### PR TITLE
feat: OKLCH カラー定義を globals.css に追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,97 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --primary: oklch(0.35 0.08 230);
+  --primary-foreground: oklch(0.98 0 0);
+  --secondary: oklch(0.45 0.06 260);
+  --secondary-foreground: oklch(0.98 0 0);
+  --success: oklch(0.65 0.17 160);
+  --success-foreground: oklch(0.98 0 0);
+  --warning: oklch(0.75 0.15 85);
+  --warning-foreground: oklch(0.1 0 0);
+  --danger: oklch(0.55 0.22 27);
+  --danger-foreground: oklch(0.98 0 0);
+  --info: oklch(0.55 0.15 230);
+  --info-foreground: oklch(0.98 0 0);
+  --background: oklch(0.98 0 0);
+  --foreground: oklch(0.15 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.15 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.15 0 0);
+  --muted: oklch(0.95 0 0);
+  --muted-foreground: oklch(0.45 0 0);
+  --accent: oklch(0.95 0 0);
+  --accent-foreground: oklch(0.15 0 0);
+  --border: oklch(0.9 0 0);
+  --input: oklch(0.9 0 0);
+  --ring: oklch(0.35 0.08 230);
+  --radius: 0.5rem;
+}
+
+.dark {
+  --primary: oklch(0.55 0.1 230);
+  --primary-foreground: oklch(0.1 0 0);
+  --secondary: oklch(0.35 0.06 260);
+  --secondary-foreground: oklch(0.98 0 0);
+  --success: oklch(0.55 0.15 160);
+  --success-foreground: oklch(0.98 0 0);
+  --warning: oklch(0.65 0.13 85);
+  --warning-foreground: oklch(0.1 0 0);
+  --danger: oklch(0.5 0.2 27);
+  --danger-foreground: oklch(0.98 0 0);
+  --info: oklch(0.5 0.13 230);
+  --info-foreground: oklch(0.98 0 0);
+  --background: oklch(0.12 0 0);
+  --foreground: oklch(0.95 0 0);
+  --card: oklch(0.15 0 0);
+  --card-foreground: oklch(0.95 0 0);
+  --popover: oklch(0.15 0 0);
+  --popover-foreground: oklch(0.95 0 0);
+  --muted: oklch(0.2 0 0);
+  --muted-foreground: oklch(0.6 0 0);
+  --accent: oklch(0.2 0 0);
+  --accent-foreground: oklch(0.95 0 0);
+  --border: oklch(0.25 0 0);
+  --input: oklch(0.25 0 0);
+  --ring: oklch(0.55 0.1 230);
+}
+
+@theme inline {
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-danger: var(--danger);
+  --color-danger-foreground: var(--danger-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}


### PR DESCRIPTION
## 概要

Issue #1 の対応として、globals.css に OKLCH カラーシステムと @theme inline を使ったカラー定義を追加しました。

## 変更内容

- OKLCH 形式でカラーパレット（primary, secondary, success, warning, danger, info, background, foreground 等）を定義
- @theme inline を使ってダークモード対応
- ライトモード（:root）とダークモード（.dark）の両方に対応
- Tailwind CSS v4 のユーティリティクラスとして公開

## Acceptance Criteria

- [x] OKLCH 形式でカラーパレットを定義
- [x] @theme inline を使ってダークモード対応
- [x] プライマリ、セカンダリ、背景、テキストなどの主要カラーを定義
- [ ] 既存コンポーネントで正常に適用されることを確認（※環境構築後に確認）

## 備考

現時点では Next.js プロジェクト自体がまだセットアップされていないため、実際の動作確認は Issue #2（環境構築）完了後に行う必要があります。

Closes #1