### PR TITLE
feat: Auth.js v5 + 認証画面（ログイン / サインアップ / proxy.ts）

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+const LoginPage = () => {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setIsLoading(true);
+
+    try {
+      const result = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+      });
+
+      if (result?.error) {
+        setError("メールアドレスまたはパスワードが正しくありません");
+      } else {
+        router.push("/dashboard");
+        router.refresh();
+      }
+    } catch (err) {
+      setError("ログインに失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-primary">Devin Task Board</h1>
+          <p className="mt-2 text-muted-foreground">
+            アカウントにログインしてください
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-8 shadow-sm">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-foreground"
+              >
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="user@example.com"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="password"
+                className="block text-sm font-medium text-foreground"
+              >
+                パスワード
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="••••••••"
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-md bg-danger/10 p-3 text-sm text-danger">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="w-full rounded-md bg-primary px-4 py-2 text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {isLoading ? "ログイン中..." : "ログイン"}
+            </button>
+          </form>
+
+          <div className="mt-6 text-center text-sm text-muted-foreground">
+            <p>
+              アカウントをお持ちでない方は{" "}
+              <a href="/signup" className="text-primary hover:underline">
+                サインアップ
+              </a>
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 text-center text-xs text-muted-foreground">
+          <p>デモアカウント: admin@example.com / password123</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+const SignupPage = () => {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (password !== confirmPassword) {
+      setError("パスワードが一致しません");
+      return;
+    }
+
+    if (password.length < 8) {
+      setError("パスワードは8文字以上で入力してください");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const res = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, password }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error?.message || "サインアップに失敗しました");
+        return;
+      }
+
+      router.push("/login?registered=true");
+    } catch (err) {
+      setError("サインアップに失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-primary">Devin Task Board</h1>
+          <p className="mt-2 text-muted-foreground">
+            新しいアカウントを作成
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-8 shadow-sm">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label
+                htmlFor="name"
+                className="block text-sm font-medium text-foreground"
+              >
+                名前
+              </label>
+              <input
+                id="name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="山田太郎"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-foreground"
+              >
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="user@example.com"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="password"
+                className="block text-sm font-medium text-foreground"
+              >
+                パスワード
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="••••••••"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="confirmPassword"
+                className="block text-sm font-medium text-foreground"
+              >
+                パスワード（確認）
+              </label>
+              <input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="••••••••"
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-md bg-danger/10 p-3 text-sm text-danger">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="w-full rounded-md bg-primary px-4 py-2 text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {isLoading ? "作成中..." : "アカウントを作成"}
+            </button>
+          </form>
+
+          <div className="mt-6 text-center text-sm text-muted-foreground">
+            <p>
+              すでにアカウントをお持ちの方は{" "}
+              <a href="/login" className="text-primary hover:underline">
+                ログイン
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignupPage;

--- a/src/app/(main)/board/page.tsx
+++ b/src/app/(main)/board/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Task = {
+  id: string;
+  taskNumber: number;
+  title: string;
+  status: string;
+  priority: string;
+  project: {
+    key: string;
+  };
+  assignee: {
+    name: string;
+  } | null;
+};
+
+const COLUMNS = [
+  { id: "BACKLOG", title: "バックログ", color: "border-muted" },
+  { id: "TODO", title: "TODO", color: "border-info" },
+  { id: "IN_PROGRESS", title: "進行中", color: "border-warning" },
+  { id: "IN_REVIEW", title: "レビュー中", color: "border-secondary" },
+  { id: "DONE", title: "完了", color: "border-success" },
+];
+
+const BoardPage = () => {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetchTasks();
+  }, []);
+
+  const fetchTasks = async () => {
+    try {
+      const res = await fetch("/api/tasks");
+      if (res.ok) {
+        const { data } = await res.json();
+        setTasks(data);
+      }
+    } catch (error) {
+      console.error("Failed to fetch tasks:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getTasksByStatus = (status: string) => {
+    return tasks.filter((task) => task.status === status);
+  };
+
+  const getPriorityColor = (priority: string) => {
+    switch (priority) {
+      case "URGENT":
+        return "border-l-4 border-l-danger";
+      case "HIGH":
+        return "border-l-4 border-l-warning";
+      case "MEDIUM":
+        return "border-l-4 border-l-info";
+      default:
+        return "";
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full p-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-foreground">カンバンボード</h1>
+        <p className="mt-2 text-muted-foreground">
+          タスクをステータス別に管理
+        </p>
+      </div>
+
+      <div className="flex gap-4 overflow-x-auto pb-4">
+        {COLUMNS.map((column) => {
+          const columnTasks = getTasksByStatus(column.id);
+          return (
+            <div
+              key={column.id}
+              className="flex-shrink-0 w-80 rounded-lg border border-border bg-card"
+            >
+              <div
+                className={`border-b-2 ${column.color} bg-muted/50 px-4 py-3`}
+              >
+                <h3 className="font-semibold text-foreground">
+                  {column.title}
+                  <span className="ml-2 text-sm text-muted-foreground">
+                    ({columnTasks.length})
+                  </span>
+                </h3>
+              </div>
+
+              <div className="space-y-3 p-4 min-h-[200px]">
+                {columnTasks.length === 0 ? (
+                  <p className="text-center text-sm text-muted-foreground py-8">
+                    タスクなし
+                  </p>
+                ) : (
+                  columnTasks.map((task) => (
+                    <div
+                      key={task.id}
+                      className={`rounded-md border border-border bg-background p-4 shadow-sm hover:shadow-md transition-shadow cursor-pointer ${getPriorityColor(
+                        task.priority
+                      )}`}
+                    >
+                      <div className="mb-2 flex items-start justify-between">
+                        <span className="text-xs text-muted-foreground">
+                          {task.project.key}-{task.taskNumber}
+                        </span>
+                        {task.priority !== "NONE" && (
+                          <span className="text-xs font-medium text-muted-foreground">
+                            {task.priority}
+                          </span>
+                        )}
+                      </div>
+                      <h4 className="mb-2 text-sm font-medium text-foreground">
+                        {task.title}
+                      </h4>
+                      {task.assignee && (
+                        <div className="flex items-center gap-2">
+                          <div className="h-6 w-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs">
+                            {task.assignee.name.charAt(0)}
+                          </div>
+                          <span className="text-xs text-muted-foreground">
+                            {task.assignee.name}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default BoardPage;

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,0 +1,60 @@
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+
+const DashboardPage = async () => {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="p-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-foreground">ダッシュボード</h1>
+        <p className="mt-2 text-muted-foreground">
+          ようこそ、{session.user.name}さん
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            総タスク数
+          </h3>
+          <p className="mt-2 text-3xl font-bold text-foreground">0</p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            進行中
+          </h3>
+          <p className="mt-2 text-3xl font-bold text-info">0</p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h3 className="text-sm font-medium text-muted-foreground">完了</h3>
+          <p className="mt-2 text-3xl font-bold text-success">0</p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            期限切れ
+          </h3>
+          <p className="mt-2 text-3xl font-bold text-danger">0</p>
+        </div>
+      </div>
+
+      <div className="mt-8 rounded-lg border border-border bg-card p-6">
+        <h2 className="text-xl font-semibold text-foreground">
+          最近のタスク
+        </h2>
+        <p className="mt-4 text-center text-muted-foreground">
+          タスクがまだありません
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,0 +1,16 @@
+import { Header } from '@/components/layout/Header';
+import { Sidebar } from '@/components/layout/Sidebar';
+
+const MainLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="flex h-screen flex-col">
+      <Header />
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar />
+        <main className="flex-1 overflow-y-auto bg-background">{children}</main>
+      </div>
+    </div>
+  );
+};
+
+export default MainLayout;

--- a/src/app/(main)/tasks/page.tsx
+++ b/src/app/(main)/tasks/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+type Task = {
+  id: string;
+  taskNumber: number;
+  title: string;
+  status: string;
+  priority: string;
+  project: {
+    id: string;
+    name: string;
+    key: string;
+  };
+  assignee: {
+    id: string;
+    name: string;
+  } | null;
+};
+
+const TasksPage = () => {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  useEffect(() => {
+    fetchTasks();
+  }, []);
+
+  const fetchTasks = async () => {
+    try {
+      const res = await fetch("/api/tasks");
+      if (res.ok) {
+        const { data } = await res.json();
+        setTasks(data);
+      }
+    } catch (error) {
+      console.error("Failed to fetch tasks:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "BACKLOG":
+        return "bg-muted text-muted-foreground";
+      case "TODO":
+        return "bg-info/10 text-info";
+      case "IN_PROGRESS":
+        return "bg-warning/10 text-warning";
+      case "IN_REVIEW":
+        return "bg-secondary/10 text-secondary";
+      case "DONE":
+        return "bg-success/10 text-success";
+      default:
+        return "bg-muted text-muted-foreground";
+    }
+  };
+
+  const getPriorityColor = (priority: string) => {
+    switch (priority) {
+      case "URGENT":
+        return "text-danger";
+      case "HIGH":
+        return "text-warning";
+      case "MEDIUM":
+        return "text-info";
+      case "LOW":
+        return "text-muted-foreground";
+      default:
+        return "text-muted-foreground";
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8">
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">タスク一覧</h1>
+          <p className="mt-2 text-muted-foreground">
+            全 {tasks.length} 件のタスク
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreateForm(true)}
+          className="rounded-md bg-primary px-4 py-2 text-primary-foreground hover:opacity-90"
+        >
+          + 新規タスク
+        </button>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead className="border-b border-border bg-muted/50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  ID
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  タイトル
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  ステータス
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  優先度
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  担当者
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  プロジェクト
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {tasks.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-6 py-8 text-center">
+                    <p className="text-muted-foreground">
+                      タスクがまだありません
+                    </p>
+                  </td>
+                </tr>
+              ) : (
+                tasks.map((task) => (
+                  <tr
+                    key={task.id}
+                    className="hover:bg-muted/50 cursor-pointer"
+                  >
+                    <td className="px-6 py-4 text-sm text-muted-foreground">
+                      {task.project.key}-{task.taskNumber}
+                    </td>
+                    <td className="px-6 py-4">
+                      <Link
+                        href={`/tasks/${task.id}`}
+                        className="text-sm font-medium text-foreground hover:text-primary"
+                      >
+                        {task.title}
+                      </Link>
+                    </td>
+                    <td className="px-6 py-4">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold ${getStatusColor(
+                          task.status
+                        )}`}
+                      >
+                        {task.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4">
+                      <span
+                        className={`text-sm font-medium ${getPriorityColor(
+                          task.priority
+                        )}`}
+                      >
+                        {task.priority}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-foreground">
+                      {task.assignee?.name || "未割り当て"}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-muted-foreground">
+                      {task.project.name}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TasksPage;

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/lib/auth';
+
+export const { GET, POST } = handlers;

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import * as bcrypt from 'bcrypt';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+
+import type { NextRequest } from 'next/server';
+
+const signupSchema = z.object({
+  name: z.string().min(1, '名前は必須です'),
+  email: z.string().email('有効なメールアドレスを入力してください'),
+  password: z.string().min(8, 'パスワードは8文字以上で入力してください'),
+});
+
+export const POST = async (request: NextRequest) => {
+  try {
+    const body = await request.json();
+    const parsed = signupSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: parsed.error.errors[0].message,
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    const { name, email, password } = parsed.data;
+
+    const existingUser = await prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (existingUser) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'USER_EXISTS',
+            message: 'このメールアドレスは既に登録されています',
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    const user = await prisma.user.create({
+      data: {
+        name,
+        email,
+        password: hashedPassword,
+        role: 'MEMBER',
+        locale: 'ja',
+        theme: 'SYSTEM',
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        createdAt: true,
+      },
+    });
+
+    return NextResponse.json({ data: user }, { status: 201 });
+  } catch (error) {
+    console.error('[POST /api/auth/signup]', error);
+    return NextResponse.json(
+      {
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'サーバーエラーが発生しました',
+        },
+      },
+      { status: 500 }
+    );
+  }
+};

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,0 +1,171 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { auth } from '@/lib/auth';
+
+import type { NextRequest } from 'next/server';
+
+const createTaskSchema = z.object({
+  title: z.string().min(1, 'タイトルは必須です'),
+  description: z.string().optional(),
+  projectId: z.string().cuid('無効なプロジェクトIDです'),
+  priority: z.enum(['URGENT', 'HIGH', 'MEDIUM', 'LOW', 'NONE']).default('NONE'),
+  assigneeId: z.string().cuid().optional(),
+  dueDate: z.string().datetime().optional(),
+  estimatedHours: z.number().positive().optional(),
+});
+
+export const GET = async (request: NextRequest) => {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHORIZED', message: '認証が必要です' } },
+        { status: 401 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('projectId');
+    const status = searchParams.get('status');
+
+    const where: any = {};
+    if (projectId) where.projectId = projectId;
+    if (status) where.status = status;
+
+    const tasks = await prisma.task.findMany({
+      where,
+      include: {
+        project: {
+          select: {
+            id: true,
+            name: true,
+            key: true,
+          },
+        },
+        assignee: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            avatarUrl: true,
+          },
+        },
+        reporter: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            avatarUrl: true,
+          },
+        },
+        categories: {
+          include: {
+            category: true,
+          },
+        },
+      },
+      orderBy: [{ status: 'asc' }, { sortOrder: 'asc' }, { createdAt: 'desc' }],
+    });
+
+    return NextResponse.json({ data: tasks });
+  } catch (error) {
+    console.error('[GET /api/tasks]', error);
+    return NextResponse.json(
+      {
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'サーバーエラーが発生しました',
+        },
+      },
+      { status: 500 }
+    );
+  }
+};
+
+export const POST = async (request: NextRequest) => {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHORIZED', message: '認証が必要です' } },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const parsed = createTaskSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: parsed.error.errors[0].message,
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    const { projectId, dueDate, ...data } = parsed.data;
+
+    const lastTask = await prisma.task.findFirst({
+      where: { projectId },
+      orderBy: { taskNumber: 'desc' },
+      select: { taskNumber: true },
+    });
+
+    const taskNumber = (lastTask?.taskNumber || 0) + 1;
+
+    const task = await prisma.task.create({
+      data: {
+        ...data,
+        projectId,
+        reporterId: session.user.id,
+        taskNumber,
+        status: 'BACKLOG',
+        sortOrder: 0,
+        dueDate: dueDate ? new Date(dueDate) : null,
+      },
+      include: {
+        project: {
+          select: {
+            id: true,
+            name: true,
+            key: true,
+          },
+        },
+        assignee: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            avatarUrl: true,
+          },
+        },
+        reporter: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            avatarUrl: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({ data: task }, { status: 201 });
+  } catch (error) {
+    console.error('[POST /api/tasks]', error);
+    return NextResponse.json(
+      {
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'サーバーエラーが発生しました',
+        },
+      },
+      { status: 500 }
+    );
+  }
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { SessionProvider } from '@/components/providers/SessionProvider';
+import { ThemeProvider } from '@/components/providers/ThemeProvider';
 
 export const metadata: Metadata = {
   title: 'Devin Task Board',
@@ -11,7 +12,9 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="ja">
       <body>
-        <SessionProvider>{children}</SessionProvider>
+        <ThemeProvider>
+          <SessionProvider>{children}</SessionProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import './globals.css';
+import { SessionProvider } from '@/components/providers/SessionProvider';
 
 export const metadata: Metadata = {
   title: 'Devin Task Board',
@@ -9,7 +10,9 @@ export const metadata: Metadata = {
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body>
+        <SessionProvider>{children}</SessionProvider>
+      </body>
     </html>
   );
 };

--- a/src/app/proxy.ts
+++ b/src/app/proxy.ts
@@ -1,0 +1,34 @@
+import { auth } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+import type { NextRequest } from 'next/server';
+
+export const config = {
+  matcher: [
+    '/((?!api/auth|login|signup|_next/static|_next/image|favicon.ico).*)',
+  ],
+};
+
+export const middleware = async (request: NextRequest) => {
+  const session = await auth();
+
+  const isAuthPage =
+    request.nextUrl.pathname === '/login' ||
+    request.nextUrl.pathname === '/signup';
+
+  if (!session && !isAuthPage) {
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('callbackUrl', request.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  if (session && isAuthPage) {
+    return NextResponse.redirect(new URL('/dashboard', request.url));
+  }
+
+  if (session && request.nextUrl.pathname === '/') {
+    return NextResponse.redirect(new URL('/dashboard', request.url));
+  }
+
+  return NextResponse.next();
+};

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { signOut, useSession } from "next-auth/react";
+import { useState } from "react";
+
+export const Header = () => {
+  const { data: session } = useSession();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const handleSignOut = async () => {
+    await signOut({ callbackUrl: "/login" });
+  };
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-border bg-card">
+      <div className="flex h-16 items-center justify-between px-6">
+        <div className="flex items-center gap-4">
+          <button
+            className="lg:hidden rounded-md p-2 hover:bg-accent"
+            onClick={() => setIsMenuOpen(!isMenuOpen)}
+          >
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-primary">Devin Task Board</h1>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <button className="rounded-md p-2 hover:bg-accent">
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+              />
+            </svg>
+          </button>
+
+          <div className="relative">
+            <button
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
+              className="flex items-center gap-2 rounded-md p-2 hover:bg-accent"
+            >
+              <div className="h-8 w-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-medium">
+                {session?.user?.name?.charAt(0).toUpperCase() || "U"}
+              </div>
+              <span className="hidden md:block text-sm font-medium">
+                {session?.user?.name}
+              </span>
+            </button>
+
+            {isMenuOpen && (
+              <div className="absolute right-0 mt-2 w-48 rounded-md border border-border bg-card shadow-lg">
+                <div className="p-2">
+                  <button
+                    onClick={handleSignOut}
+                    className="w-full rounded-md px-3 py-2 text-left text-sm hover:bg-accent"
+                  >
+                    ログアウト
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export const Sidebar = () => {
+  const pathname = usePathname();
+
+  const navItems = [
+    {
+      name: "ダッシュボード",
+      href: "/dashboard",
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+          />
+        </svg>
+      ),
+    },
+    {
+      name: "プロジェクト",
+      href: "/projects",
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+          />
+        </svg>
+      ),
+    },
+    {
+      name: "タスク",
+      href: "/tasks",
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+          />
+        </svg>
+      ),
+    },
+    {
+      name: "カンバン",
+      href: "/board",
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"
+          />
+        </svg>
+      ),
+    },
+    {
+      name: "通知",
+      href: "/notifications",
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+          />
+        </svg>
+      ),
+    },
+    {
+      name: "設定",
+      href: "/settings",
+      icon: (
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+        </svg>
+      ),
+    },
+  ];
+
+  return (
+    <aside className="hidden lg:flex w-64 flex-col border-r border-border bg-card">
+      <nav className="flex-1 space-y-1 p-4">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : "text-foreground hover:bg-accent"
+              }`}
+            >
+              {item.icon}
+              {item.name}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+};

--- a/src/components/providers/SessionProvider.tsx
+++ b/src/components/providers/SessionProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { SessionProvider as NextAuthSessionProvider } from "next-auth/react";
+
+export const SessionProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return <NextAuthSessionProvider>{children}</NextAuthSessionProvider>;
+};

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+type ThemeContextType = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>("system");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const stored = localStorage.getItem("theme") as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    const root = window.document.documentElement;
+    root.classList.remove("light", "dark");
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light";
+      root.classList.add(systemTheme);
+    } else {
+      root.classList.add(theme);
+    }
+
+    localStorage.setItem("theme", theme);
+  }, [theme, mounted]);
+
+  if (!mounted) {
+    return <>{children}</>;
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+};

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,76 @@
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+import * as bcrypt from 'bcrypt';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+import type { User } from '@prisma/client';
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      authorize: async (credentials) => {
+        const parsed = loginSchema.safeParse(credentials);
+        if (!parsed.success) return null;
+
+        const { email, password } = parsed.data;
+
+        const user = await prisma.user.findUnique({
+          where: { email },
+        });
+
+        if (!user) return null;
+
+        const isValid = await bcrypt.compare(password, user.password);
+        if (!isValid) return null;
+
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          image: user.avatarUrl,
+        };
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = user.id;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = token.id as string;
+      }
+      return session;
+    },
+  },
+  pages: {
+    signIn: '/login',
+  },
+  session: {
+    strategy: 'jwt',
+  },
+});
+
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id: string;
+      email: string;
+      name: string;
+      image?: string | null;
+    };
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## 概要

Issue #4 の対応として、Auth.js v5 を導入し、ログイン・サインアップ画面と認証プロキシを実装しました。

## 変更内容

### Auth.js v5 設定
- Credentials Provider を使用
- JWT ベースのセッション管理
- bcrypt でパスワードをハッシュ化

### 認証画面
- **ログイン画面**（/login）
  - メールアドレス・パスワード入力
  - エラーハンドリング
  - デモアカウント情報表示
- **サインアップ画面**（/signup）
  - 名前・メールアドレス・パスワード入力
  - パスワード確認
  - バリデーション

### API
- **サインアップ API**（/api/auth/signup）
  - zod でバリデーション
  - 重複メールチェック
  - ユーザー作成

### 認証プロキシ（proxy.ts）
- 未認証ユーザーを /login にリダイレクト
- 認証済みユーザーが認証ページにアクセスした場合は /dashboard にリダイレクト
- ルートパス（/）は /dashboard にリダイレクト

### その他
- SessionProvider を追加
- ダッシュボードページを実装
- Prisma Client シングルトンを作成

## Acceptance Criteria

- [x] Auth.js v5 をセットアップ
- [x] ログイン画面を実装
- [x] サインアップ画面を実装
- [x] proxy.ts で認証状態を管理
- [x] 認証が必要なページへのアクセス制御が動作
- [x] セッション管理が正常に機能

## デモアカウント

- **メールアドレス**: admin@example.com
- **パスワード**: password123

Closes #4